### PR TITLE
Priority Queue Example in java

### DIFF
--- a/Queue/QueueCode.java
+++ b/Queue/QueueCode.java
@@ -1,0 +1,45 @@
+import java.util.*;  
+class Book implements Comparable<Book>{  
+int id;  
+String name,author,publisher;  
+int quantity;  
+public Book(int id, String name, String author, String publisher, int quantity) {  
+    this.id = id;  
+    this.name = name;  
+    this.author = author;  
+    this.publisher = publisher;  
+    this.quantity = quantity;  
+}  
+public int compareTo(Book b) {  
+    if(id>b.id){  
+        return 1;  
+    }else if(id<b.id){  
+        return -1;  
+    }else{  
+    return 0;  
+    }  
+}  
+}  
+public class LinkedListExample {  
+public static void main(String[] args) {  
+    Queue<Book> queue=new PriorityQueue<Book>();  
+    //Creating Books  
+    Book b1=new Book(121,"Let us C","Yashwant Kanetkar","BPB",8);  
+    Book b2=new Book(233,"Operating System","Galvin","Wiley",6);  
+    Book b3=new Book(101,"Data Communications & Networking","Forouzan","Mc Graw Hill",4);  
+    //Adding Books to the queue  
+    queue.add(b1);  
+    queue.add(b2);  
+    queue.add(b3);  
+    System.out.println("Traversing the queue elements:");  
+    //Traversing queue elements  
+    for(Book b:queue){  
+    System.out.println(b.id+" "+b.name+" "+b.author+" "+b.publisher+" "+b.quantity);  
+    }  
+    queue.remove();  
+    System.out.println("After removing one book record:");  
+    for(Book b:queue){  
+        System.out.println(b.id+" "+b.name+" "+b.author+" "+b.publisher+" "+b.quantity);  
+        }  
+}  
+}  


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy Contributing!

-->

### Have you read the [Contributing Guidelines on Pull Requests](https://github.com/ananddasani/Java-Practice-Course/blob/main/CONTRIBUTING.md)?

(Write your answer here.) Yes

### Description

(Write your answer here.)
Let's see a PriorityQueue example where we are adding books to queue and printing all the books. The elements in PriorityQueue must be of Comparable type. String and Wrapper classes are Comparable by default. To add user-defined objects in PriorityQueue, you need to implement Comparable interface.

### Checklist

- [.] I've read the contribution guidelines.
- [.] I've checked the issue list before deciding what to submit.
- [.] I've added only `source code file`.

## Related Issues or Pull Requests

(Write your answer here.)

---No Issues

(To fasten your PR review process mention me (@ananddasani))
@ananddasani 
